### PR TITLE
fix: code タグの背景色を pre タグ配下の code タグに適応させてしまっている不具合の修正

### DIFF
--- a/marogosteen-pages/src/components/BlogPost.astro
+++ b/marogosteen-pages/src/components/BlogPost.astro
@@ -76,13 +76,13 @@ const isShowUpdate = publicDate !== updateDate;
         @apply indent-0 rounded-xl w-10/12 my-10 mx-auto;
     }
     article :global(code) {
-        @apply relative text-white p-1 mx-1 text-sm bg-gray-700 rounded-lg px-3;
+        @apply text-white text-sm py-0.5 mx-0.5 px-3 bg-gray-700 rounded-lg;
     }
     article :global(pre) {
-        @apply p-5 my-10 rounded-lg flex overflow-x-auto;
+        @apply p-2 my-5 rounded-lg flex overflow-x-auto;
     }
     article :global(pre > code) {
-        @apply px-0 flex-none w-10;
+        @apply bg-inherit;
     }
     article :global(table) {
         @apply mx-auto my-10 text-sm sm:text-base;


### PR DESCRIPTION
close #30 